### PR TITLE
Users generation

### DIFF
--- a/tasks/populate_users.rb
+++ b/tasks/populate_users.rb
@@ -1,0 +1,6 @@
+require_relative '../config/requirements'
+
+settings = Settings.new('settings.yml')
+
+application = Application.new(settings)
+application.pull_user_data


### PR DESCRIPTION
This adds a task that automatically generates slack user data to save you from having to manually input everything into config/users.yml
